### PR TITLE
DarkSky api call functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ instance/
 
 # vim swap files
 .*.swp
+
+# pytest
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,9 @@ docs/_build/
 # PyBuilder
 target/
 
-venv
+venv/
+instance/
+.mypy_cache/
 
 # vim swap files
 .*.swp

--- a/darksky.py
+++ b/darksky.py
@@ -6,8 +6,6 @@ Requests data from the weather api.
 import requests
 from requests.exceptions import InvalidHeader
 
-import instance.config  # modify this once flask is set up *****
-
 
 class DarkSky(object):
 
@@ -17,6 +15,9 @@ class DarkSky(object):
         """
         :key is the secret api key
         """
+        if not key:
+            raise TypeError(
+                "Missing argument. Key is required.")
         self.key = key
 
     def request(self,
@@ -35,9 +36,9 @@ class DarkSky(object):
         :timeout is in seconds
         """
 
-        if not self.key or not latitude or not longitude:
+        if not latitude or not longitude:
             raise TypeError(
-                "Missing argument. key, latitude and longitude are required.")
+                "Missing argument. Latitude and longitude are required.")
 
         url = ("https://api.darksky.net/forecast/{key}/{lat},{lon}".format(
                    key=instance.config.DARK_SKY_API_KEY,
@@ -57,11 +58,12 @@ class DarkSky(object):
             raise InvalidHeader(
                     "Content type is not JSON as expected: {}".format(
                         content_type))
-
         return r
 
 
 if __name__ == '__main__':
+    import instance.config  # modify this once flask is set up *****
+
     dark_sky = DarkSky(key=instance.config.DARK_SKY_API_KEY)
     try:
         r = dark_sky.request(latitude=instance.config.LATITUDE,

--- a/darksky.py
+++ b/darksky.py
@@ -38,10 +38,10 @@ class DarkSky(object):
 
         if not latitude or not longitude:
             raise TypeError(
-                "Missing argument. Latitude and longitude are required.")
+                "Missing argument. Latitude and Longitude are required.")
 
         url = ("https://api.darksky.net/forecast/{key}/{lat},{lon}".format(
-                   key=instance.config.DARK_SKY_API_KEY,
+                   key=self.key,
                    lat=latitude,
                    lon=longitude))
 

--- a/get_from_api.py
+++ b/get_from_api.py
@@ -13,7 +13,8 @@ def dark_sky_call(
         latitude,
         longitude,
         options={'units': 'si', 'extend': 'hourly'},
-        headers={'Accept-Encoding': 'gzip'}):
+        headers={'Accept-Encoding': 'gzip'},
+        timeout=2):
 
     call = (
         'https://api.darksky.net/forecast/' +
@@ -31,4 +32,8 @@ if __name__ == '__main__':
             instance.config.LONGITUDE)
 
     print(r.url)
-    print(r.text)
+    # print(r.text)
+    print(r.status_code)
+    print(r.status_code == requests.codes.ok)
+    print(r.headers)  # test on Content-Encoding and Content-Type
+    # print(r.json())  # raises an exception if unable to decode

--- a/get_from_api.py
+++ b/get_from_api.py
@@ -1,26 +1,31 @@
-'''
-Requests data from the weather api.
-
-Http gzip compression should be enabled.
-'''
+'''Requests data from the weather api.'''
 
 import requests
 import instance.config  # modify this once flask is set up *****
 
 
 def dark_sky_call(
-        key,
-        latitude,
-        longitude,
-        options={'units': 'si', 'extend': 'hourly'},
-        headers={'Accept-Encoding': 'gzip'},
-        timeout=2):
+                key,
+                latitude,
+                longitude,
+                options={'units': 'si', 'extend': 'hourly'},
+                headers={'Accept-Encoding': 'gzip'},
+                timeout=2):
+    '''
+    Returns a request object from the Dark Sky API.
+
+    key is the secret api key
+    latitude and longitude can be supplied as string or float
+    options are converted into query string paramaters
+    headers includes http gzip conversion by default
+    timeout is in seconds
+    '''
 
     call = (
-        'https://api.darksky.net/forecast/' +
-        instance.config.DARK_SKY_API_KEY + '/' +
-        str(latitude) + ',' +
-        str(longitude))
+        'https://api.darksky.net/forecast/'
+        + instance.config.DARK_SKY_API_KEY + '/'
+        + str(latitude) + ','
+        + str(longitude))
 
     return requests.get(call, params=options, headers=headers)
 
@@ -32,8 +37,8 @@ if __name__ == '__main__':
             instance.config.LONGITUDE)
 
     print(r.url)
-    # print(r.text)
     print(r.status_code)
     print(r.status_code == requests.codes.ok)
     print(r.headers)  # test on Content-Encoding and Content-Type
+    # print(r.text)
     # print(r.json())  # raises an exception if unable to decode

--- a/get_from_api.py
+++ b/get_from_api.py
@@ -5,17 +5,30 @@ Http gzip compression should be enabled.
 '''
 
 import requests
-import instance.config # modify this once flask is set up *****
+import instance.config  # modify this once flask is set up *****
 
-dark_sky_call = (
-        'https://api.darksky.net/forecast/'
-        + instance.config.DARK_SKY_API_KEY + '/'
-        + str(instance.config.LATITUDE) + ','
-        + str(instance.config.LONGITUDE))
-call_options = {'units': 'si', 'extend': 'hourly'}
-call_headers = {'Accept-Encoding': 'gzip'}
 
-r = requests.get(dark_sky_call, params=call_options, headers=call_headers)
+def dark_sky_call(
+        key,
+        latitude,
+        longitude,
+        options={'units': 'si', 'extend': 'hourly'},
+        headers={'Accept-Encoding': 'gzip'}):
 
-print(r.url)
-print(r.text)
+    call = (
+        'https://api.darksky.net/forecast/' +
+        instance.config.DARK_SKY_API_KEY + '/' +
+        str(latitude) + ',' +
+        str(longitude))
+
+    return requests.get(call, params=options, headers=headers)
+
+
+if __name__ == '__main__':
+    r = dark_sky_call(
+            instance.config.DARK_SKY_API_KEY,
+            instance.config.LATITUDE,
+            instance.config.LONGITUDE)
+
+    print(r.url)
+    print(r.text)

--- a/get_from_api.py
+++ b/get_from_api.py
@@ -1,0 +1,21 @@
+'''
+Requests data from the weather api.
+
+Http gzip compression should be enabled.
+'''
+
+import requests
+import instance.config # modify this once flask is set up *****
+
+dark_sky_call = (
+        'https://api.darksky.net/forecast/'
+        + instance.config.DARK_SKY_API_KEY + '/'
+        + str(instance.config.LATITUDE) + ','
+        + str(instance.config.LONGITUDE))
+call_options = {'units': 'si', 'extend': 'hourly'}
+call_headers = {'Accept-Encoding': 'gzip'}
+
+r = requests.get(dark_sky_call, params=call_options, headers=call_headers)
+
+print(r.url)
+print(r.text)

--- a/get_from_api.py
+++ b/get_from_api.py
@@ -1,53 +1,75 @@
-'''Requests data from the weather api.'''
+"""
+Requests data from the weather api.
+
+"""
 
 import requests
 from requests.exceptions import InvalidHeader
+
 import instance.config  # modify this once flask is set up *****
 
 
-def dark_sky_call(
-                key=None,
+class DarkSky(object):
+
+    """A DarkSky API client."""
+
+    def __init__(self, key=None):
+        """
+        :key is the secret api key
+        """
+        self.key = key
+
+    def request(self,
                 latitude=None,
                 longitude=None,
                 options={'units': 'si', 'extend': 'hourly'},
                 headers={'Accept-Encoding': 'gzip'},
                 timeout=2):
-    '''
-    Returns a request object from the Dark Sky API.
 
-    key is the secret api key
-    latitude and longitude can be supplied as string or float
-    options are converted into query string paramaters
-    headers includes http gzip conversion by default
-    timeout is in seconds
-    '''
-    if not key or not latitude or not longitude:
-        raise TypeError(
-            "Missing argument. key, latitude and longitude are all required.")
+        """
+        Returns a request object from the Dark Sky API.
 
-    call = (
-        'https://api.darksky.net/forecast/'
-        + instance.config.DARK_SKY_API_KEY + '/'
-        + str(latitude) + ','
-        + str(longitude))
+        :latitude and longitude can be supplied as string or float
+        :options are converted into query string paramaters
+        :headers includes http gzip conversion by default
+        :timeout is in seconds
+        """
 
-    return requests.get(call, params=options, headers=headers, timeout=timeout)
+        if not self.key or not latitude or not longitude:
+            raise TypeError(
+                "Missing argument. key, latitude and longitude are required.")
+
+        url = ("https://api.darksky.net/forecast/{key}/{lat},{lon}".format(
+                   key=instance.config.DARK_SKY_API_KEY,
+                   lat=latitude,
+                   lon=longitude))
+
+        r = requests.get(url,
+                         params=options,
+                         headers=headers,
+                         timeout=timeout)
+
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
+
+        content_type = r.headers["Content-Type"]
+        if 'application/json' not in content_type:
+            raise InvalidHeader(
+                    "Content type is not JSON as expected: {}".format(
+                        content_type))
+
+        return r
 
 
 if __name__ == '__main__':
-    r = dark_sky_call(
-            key=instance.config.DARK_SKY_API_KEY,
-            latitude=instance.config.LATITUDE,
-            longitude=instance.config.LONGITUDE)
+    dark_sky = DarkSky(key=instance.config.DARK_SKY_API_KEY)
+    try:
+        r = dark_sky.request(latitude=instance.config.LATITUDE,
+                             longitude=instance.config.LONGITUDE)
+        print(r.json())  # raises an exception if unable to decode
 
-    if r.status_code != requests.codes.ok:
-        r.raise_for_status()
+    except ValueError as e:
+        print("Decoding failed: {}".format(e))
 
-    content_type = r.headers["Content-Type"]
-    if 'application/json' not in content_type:
-        raise InvalidHeader(
-                "Wrong content type in header: {}".format(content_type))
-
-    print(r.url)
-    # print(r.text)
-    # print(r.json())  # raises an exception if unable to decode
+    except Exception as e:
+        print("Error {} occurred. Retry when properly implemented".format(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
+certifi==2018.1.18
+chardet==3.0.4
 click==6.7
 Flask==0.12.2
+idna==2.6
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0
+requests==2.18.4
+urllib3==1.22
 Werkzeug==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+attrs==18.1.0
 certifi==2018.1.18
 chardet==3.0.4
 click==6.7
@@ -6,6 +7,13 @@ idna==2.6
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0
+mock==2.0.0
+more-itertools==4.1.0
+pbr==4.0.2
+pluggy==0.6.0
+py==1.5.3
+pytest==3.5.1
 requests==2.18.4
+six==1.11.0
 urllib3==1.22
 Werkzeug==0.14.1

--- a/tests/dark_sky_test.py
+++ b/tests/dark_sky_test.py
@@ -5,9 +5,10 @@ Testing the DarkSky API connector
 import mock
 import pytest
 import random
-import requests
 import string
 import unittest
+# from unittest.mock import Mock, patch
+
 from darksky import DarkSky
 
 
@@ -20,6 +21,20 @@ def _generate_random_key(length=32):
     key = ''.join(key)
     print("Generated key length {}: {}".format(length, key))
     return key
+
+
+def _mock_response(raise_for_status=None,
+                   status_code=200,
+                   content_type='application/json; charset=utf-8',
+                   content='{}'):
+    mock_resp = mock.Mock()
+    mock_resp.raise_for_status = mock.Mock()
+    if raise_for_status:
+        mock_resp.raise_for_status.side_effect = raise_for_status
+    mock_resp.status_code = status_code
+    # mock_resp.add_header("Content-Type", content_type)
+
+    return mock_resp
 
 
 def test_init_raises_TypeError_with_no_key_variable():
@@ -45,23 +60,27 @@ def darksky():
 def test_request_raises_TypeError_with_missing_lat_long(darksky):
     with pytest.raises(TypeError) as e:
         darksky.request()
-    assert ("Missing argument. Latitude and longitude are required."
+    assert ("Missing argument. Latitude and Longitude are required."
             in str(e.value))
 
 
 def test_request_raises_TypeError_with_missing_long(darksky):
     with pytest.raises(TypeError) as e:
         darksky.request(latitude='1.0')
-    assert ("Missing argument. Latitude and longitude are required."
+    assert ("Missing argument. Latitude and Longitude are required."
             in str(e.value))
 
 
 def test_request_raises_TypeError_with_missing_lat(darksky):
     with pytest.raises(TypeError) as e:
         darksky.request(longitude='1.0')
-    assert ("Missing argument. Latitude and longitude are required."
+    assert ("Missing argument. Latitude and Longitude are required."
             in str(e.value))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_response_status_code(darksky):
+    with mock.patch('dark_sky_test.requests.get') as mock_get:
+        mock_resp = _mock_response(status_code=200)
+        mock_get.return_value = mock_resp
+        result = darksky.request(latitude='1.0', longitude='1.0')
+        assert result.status_code == 100

--- a/tests/dark_sky_test.py
+++ b/tests/dark_sky_test.py
@@ -25,7 +25,6 @@ def _generate_random_key(length=32):
     return key
 
 
-# class MockedResponse(requests.Response):
 class MockedResponse(object):
     def __init__(self,
                  content='{}',
@@ -40,23 +39,14 @@ class MockedResponse(object):
                         'Expires': 'Sat, 19 May 2018 13:14:34 +0000',
                         'X-Response-Time': '152.328ms',
                         'Content-Encoding': 'gzip'},
-                 # reason=None,
-                 status_code=200,
-                 # url=None,
-                 ):
+                 status_code=200):
 
-        # import pdb; pdb.set_trace()
-        # super().__init__(*args, **kwargs)
-        # print(reason)
-        # print(url)
         self.status_code = status_code
         self.headers = headers
         self.content = content
-        # self.reason = reason
-        # self.url = url
 
     def raise_for_status(self):
-        print('Mocked raise_for_status called with tatus code {}.'.format(
+        print('Mocked raise_for_status called with status code {}.'.format(
                                                             self.status_code))
         raise HTTPError(self.status_code)
 
@@ -105,25 +95,25 @@ def test_request_raises_TypeError_with_missing_lat(darksky):
 def test_response_no_error_when_status_code_ok(darksky):
     try:
         with mock.patch('darksky.requests.get') as mock_request:
-            # mock_response = MockedResponse(status_code=200)
             mock_request.return_value = MockedResponse(status_code=200)
-            # mock_request.return_value = mock_response
             darksky.request(latitude='1.0', longitude='1.0')
     except Exception as e:
         pytest.fail(str(e))
 
 
-
 @pytest.mark.parametrize('status_code', range(400, 600))
 @mock.patch('darksky.requests.get')
-def test_response_raises_error_when_status_code_not_ok(
-                    mock_request, status_code, darksky):
+def test_response_raises_error_when_status_code_not_ok(mock_request,
+                                                       status_code,
+                                                       darksky):
     print(status_code)
     with pytest.raises(HTTPError) as e:
         mock_response = MockedResponse(status_code=status_code)
         mock_request.return_value = mock_response
         req = darksky.request(latitude='1.0', longitude='1.0')
+
         req.raise_for_status.assert_called_once_with(HTTPError)
+
         print("Error generated: {} {}".format(e.type, e.value))
         assert (str(status_code) == str(e.value))
 

--- a/tests/dark_sky_test.py
+++ b/tests/dark_sky_test.py
@@ -6,10 +6,7 @@ import mock
 import pytest
 import random
 import string
-import unittest
-import requests
-from requests.exceptions import HTTPError
-# from unittest.mock import Mock, patch
+from requests.exceptions import HTTPError, InvalidHeader
 
 from darksky import DarkSky
 
@@ -66,6 +63,7 @@ def test_init_stores_key_variable(exec_no):
     assert darksky_with_key.key == key
 
 
+# this is the setup
 @pytest.fixture
 def darksky():
     return DarkSky(key=_generate_random_key())
@@ -117,4 +115,13 @@ def test_response_raises_error_when_status_code_not_ok(mock_request,
         print("Error generated: {} {}".format(e.type, e.value))
         assert (str(status_code) == str(e.value))
 
-# 'text/html; charset=ISO-8859-1'
+
+@mock.patch('darksky.requests.get')
+def test_response_raises_error_when_header_not_json(mock_request, darksky):
+    with pytest.raises(InvalidHeader) as e:
+        mock_response = MockedResponse(headers={
+                        'Content-Type': 'text/html; charset=ISO-8859-1'})
+        mock_request.return_value = mock_response
+        darksky.request(latitude='1.0', longitude='1.0')
+
+    assert ("Content type is not JSON as expected:" in str(e.value))

--- a/tests/dark_sky_test.py
+++ b/tests/dark_sky_test.py
@@ -23,18 +23,28 @@ def _generate_random_key(length=32):
     return key
 
 
-def _mock_response(raise_for_status=None,
-                   status_code=200,
-                   content_type='application/json; charset=utf-8',
-                   content='{}'):
-    mock_resp = mock.Mock()
-    mock_resp.raise_for_status = mock.Mock()
-    if raise_for_status:
-        mock_resp.raise_for_status.side_effect = raise_for_status
-    mock_resp.status_code = status_code
-    # mock_resp.add_header("Content-Type", content_type)
+class MockedResponse(object):
+    def __init__(self,
+                 raise_for_status=None,
+                 status_code=200,
+                 headers={
+                        'Server': 'nginx',
+                        'Date': 'Sat, 19 May 2018 13:13:34 GMT',
+                        'Content-Type': 'application/json; charset=utf-8',
+                        'Transfer-Encoding': 'chunked',
+                        'Connection': 'keep-alive',
+                        'X-Forecast-API-Calls': '2',
+                        'Cache-Control': 'max-age=60',
+                        'Expires': 'Sat, 19 May 2018 13:14:34 +0000',
+                        'X-Response-Time': '152.328ms',
+                        'Content-Encoding': 'gzip'},
+                 content='{}'):
 
-    return mock_resp
+        self.raise_for_status = raise_for_status
+        self.status_code = status_code
+        self.headers = headers
+        self.content = content
+        self.raise_for_status = raise_for_status
 
 
 def test_init_raises_TypeError_with_no_key_variable():
@@ -78,9 +88,9 @@ def test_request_raises_TypeError_with_missing_lat(darksky):
             in str(e.value))
 
 
-def test_response_status_code(darksky):
-    with mock.patch('dark_sky_test.requests.get') as mock_get:
-        mock_resp = _mock_response(status_code=200)
-        mock_get.return_value = mock_resp
+def test_response_status_code_ok(darksky):
+    with mock.patch('darksky.requests.get') as mock_request:
+        mock_response = MockedResponse()
+        mock_request.return_value = mock_response
         result = darksky.request(latitude='1.0', longitude='1.0')
-        assert result.status_code == 100
+        assert result.status_code == 200

--- a/tests/dark_sky_test.py
+++ b/tests/dark_sky_test.py
@@ -1,0 +1,67 @@
+"""
+Testing the DarkSky API connector
+"""
+
+import mock
+import pytest
+import random
+import requests
+import string
+import unittest
+from darksky import DarkSky
+
+
+def _generate_random_key(length=32):
+    key = []
+    strings = string.ascii_letters + string.digits
+    for l in range(length):
+        next_letter = random.choice(strings)
+        key.append(next_letter)
+    key = ''.join(key)
+    print("Generated key length {}: {}".format(length, key))
+    return key
+
+
+def test_init_raises_TypeError_with_no_key_variable():
+    with pytest.raises(TypeError) as e:
+        DarkSky()
+    assert "Missing argument. Key is required." in str(e.value)
+
+
+# run this next test 30 times
+@pytest.mark.parametrize('exec_no', range(30))
+def test_init_stores_key_variable(exec_no):
+    key = _generate_random_key()
+    print("Test {} with key: {}".format(exec_no, key))
+    darksky_with_key = DarkSky(key=key)
+    assert darksky_with_key.key == key
+
+
+@pytest.fixture
+def darksky():
+    return DarkSky(key=_generate_random_key())
+
+
+def test_request_raises_TypeError_with_missing_lat_long(darksky):
+    with pytest.raises(TypeError) as e:
+        darksky.request()
+    assert ("Missing argument. Latitude and longitude are required."
+            in str(e.value))
+
+
+def test_request_raises_TypeError_with_missing_long(darksky):
+    with pytest.raises(TypeError) as e:
+        darksky.request(latitude='1.0')
+    assert ("Missing argument. Latitude and longitude are required."
+            in str(e.value))
+
+
+def test_request_raises_TypeError_with_missing_lat(darksky):
+    with pytest.raises(TypeError) as e:
+        darksky.request(longitude='1.0')
+    assert ("Missing argument. Latitude and longitude are required."
+            in str(e.value))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The testing is now complete: 438 tests. Run with 'pytest'. 
_~150 lines of test code to test 100 lines of code..._

Requirements.txt is updated after installing some testing stuff so you'll need to pip install -r the requirements file into your venv.

instance/config.py needs the following added:
DARK_SKY_API_KEY = 'your api key string'
LATITUDE = float or str
LONGITUDE = float or str
